### PR TITLE
3 make current timeduration responsive

### DIFF
--- a/src/components/LogoOver.astro
+++ b/src/components/LogoOver.astro
@@ -36,13 +36,10 @@ import Spitofy from "./Spitofy.svg.astro";
 
     let currentBpm = parseInt(bpm);
 
-    console.log(currentBpm);
-
     if (currentFrame - lastFrame < 1000 / (currentBpm / 60) / 4) {
       window.requestAnimationFrame(randomLogo);
       return;
     }
-    console.log("frame");
     lastFrame = currentFrame;
 
     logoover ??= document.getElementById("logoover") as HTMLElement;

--- a/src/components/Menu/AudioPlayer/AudioPlayer.astro
+++ b/src/components/Menu/AudioPlayer/AudioPlayer.astro
@@ -29,15 +29,14 @@ import WaveFormProgress from "./WaveFormProgess.astro";
     display: none;
   }
   button {
-    width: 70px;
-    height: 70px;
     background: none;
     border: none;
     cursor: url("/hand.webp"), pointer;
 
     svg {
-      width: 50px;
-      height: 50px;
+      padding: 10px;
+      width: var(--button-size);
+      height: var(--button-size);
       color: white;
     }
   }

--- a/src/components/Menu/AudioPlayer/WaveFormProgress/updateTime.ts
+++ b/src/components/Menu/AudioPlayer/WaveFormProgress/updateTime.ts
@@ -16,7 +16,7 @@ function updateTime() {
   const audio = document.getElementById("audioGlobal") as HTMLMediaElement;
 
   const span = WaveFormProgess.querySelector("span") as HTMLSpanElement;
-  span.innerText = `${secondsToHuman(audio.currentTime)} / ${secondsToHuman(
+  span.innerText = `${secondsToHuman(audio.currentTime)}/${secondsToHuman(
     audio.duration,
   )}`;
 

--- a/src/components/Menu/SubMenu/SubMenu.astro
+++ b/src/components/Menu/SubMenu/SubMenu.astro
@@ -144,8 +144,8 @@ switch (url.pathname) {
     cursor: url(/hand.webp), pointer;
     .openSubmenu {
       color: #fff;
-      height: 50px;
-      width: 50px;
+      height: var(--button-size);
+      width: var(--button-size);
     }
   }
 </style>

--- a/src/js/userRecentAction.ts
+++ b/src/js/userRecentAction.ts
@@ -28,17 +28,9 @@ documentEvents.forEach((event) => {
   document.body.addEventListener(event, removeAtTheEnd);
 });
 
-const audioEvents = [
-  "play",
-  "pause",
-  "ended",
-  "timeupdate",
-  "volumechange",
-  "ratechange",
-  "progress",
-];
+const audioEvents = ["play", "pause", "ended", "volumechange", "ratechange"];
 
-const audio = document.getElementById("audioGlobal");
+const audio = document.getElementById("audioGlobal") as HTMLMediaElement;
 audioEvents.forEach((event) => {
   audio.addEventListener(event, setAtTheBeginning);
   audio.addEventListener(event, removeAtTheEnd);

--- a/src/js/userRecentAction.ts
+++ b/src/js/userRecentAction.ts
@@ -24,8 +24,8 @@ const documentEvents = [
   "mousemove",
 ];
 documentEvents.forEach((event) => {
-  document.body.addEventListener(event, setAtTheBeginning);
-  document.body.addEventListener(event, removeAtTheEnd);
+  document.addEventListener(event, setAtTheBeginning);
+  document.addEventListener(event, removeAtTheEnd);
 });
 
 const audioEvents = ["play", "pause", "ended", "volumechange", "ratechange"];

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -43,7 +43,7 @@ const { title, track } = Astro.props;
     <Audio transition:name="audioGlobal" transition:persist track={track} />
     <slot />
     <LogoOver />
-    <style is:global>
+    <style is:global lang="scss">
       html {
         font-family: system-ui, sans-serif;
         background: #13151a;
@@ -74,6 +74,14 @@ const { title, track } = Astro.props;
         --sixteenth-note: calc(60s / var(--BPM) / 4);
         --word: calc(var(--whole-note) * 4);
         --phrase: calc(var(--word) * 4);
+
+        --button-size: 50px;
+        @media (max-width: 500px) {
+          --button-size: 40px;
+        }
+        @media (max-width: 400px) {
+          --button-size: 30px;
+        }
       }
     </style>
     <script>


### PR DESCRIPTION
It turned out that it was enough to decrease the button sizes and to remove the space between the time and the `/`

Button sizes had to be decreased anyway to make them look good at small screens.

----

I have also removed a pair of console.log that shouldn't be there

And I removed the `timeupdate` and the `progress` events from the list of events that should be considered an user action, which are used to show the UI.

With those events there, the UI will never hide when the music is playing because they trigger continuously. It's not really user action, or anything that should show the UI.

I have changed from `document.body.addEventListener` to `document.addEventListener` for the user actions listener as well because it wasn't working. 
